### PR TITLE
Tweaks file ownership task

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -44,3 +44,6 @@
     - "{{ janus_users }}"
     - "{{ janus_created_directories }}"
   become: True
+  register: ownership
+  changed_when: false
+  failed_when: "ownership.owner != '{{ item.0.user }}' or ownership.group != '{{ item.0.group }}'"


### PR DESCRIPTION
- Task never reports changed, but
- Task fails when file owner/group is not the current user.
- Closes gh-8