### PR TITLE
Changes janus_vim_plugins.update to janus_vim_plugins.updaterepo

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ repository to clone Janus from. Should seldome need changing. |
 | `janus_vim_plugins[n].url` | `-` | The url of the plugin to install. Used for the `repo` parameter of the Git module when cloning. |
 | `janus_vim_plugins[n].version` | `HEAD` | The version of the plugin to install. Used for the `version` parameter of the Git module when cloning. |
 | `janus_vim_plugins[n]force` | `false` | Whether or not to force-clone the plugin. Used for the `force` parameter of the Git module when cloning. |
-| `janus_vim_plugins[n]update` | `true` | Whether or not to update the plugin repo. Used for the `update` parameter of the Git module when cloning. |
+| `janus_vim_plugins[n]updaterepo` | `true` | Whether or not to update the plugin repo. Used for the `update` parameter of the Git module when cloning. |
 
 ## Role task fileso
 
@@ -89,10 +89,10 @@ This task installs any defined modules into the appropriate directory
         janus_vim_plugins:
           - name: "lightline.vim"
             url: "https://github.com/itchyny/lightline.vim"
-            update: false
+            updaterepo: false
           - name: "vim-surround"
             url: "https://github.com/tpope/vim-surround.git"
-            update: true
+            updaterepo: true
         janus_backup_files:
           - ".vimrc"
       tasks:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,9 +21,9 @@ janus_vim_plugins: []
 #    url: "https://github.com/joonty/vdebug.git"
 #    version: "HEAD"
 #    force: true
-#    update: true
+#    updaterepo: true
 #  - name: "vim-surround"
 #    url: "https://github.com/tpope/vim-surround.git"
 #    version: "HEAD"
 #    force: true
-#    update: true
+#    updaterepo: true

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -10,10 +10,10 @@
     janus_vim_plugins:
       - name: "lightline.vim"
         url: "https://github.com/itchyny/lightline.vim"
-        update: false
+        updaterepo: false
       - name: "vim-surround"
         url: "https://github.com/tpope/vim-surround.git"
-        update: true
+        updaterepo: true
     janus_backup_files:
       - ".vimrc"
   tasks:

--- a/tasks/plugins.yml
+++ b/tasks/plugins.yml
@@ -13,9 +13,7 @@
     repo: "{{ plugin.url }}"
     dest: "{{ janus_plugin_install_path }}/{{ plugin.name }}"
     force: "{{ plugin.force | default(false) }}"
-    # Note: this deviation in code style necessitated by a weird Ansible bug:
-    # https://git.io/fN1Tc
-    update: "{{ plugin['update'] | default(true) }}"
+    update: "{{ plugin.updaterepo | default(true) }}"
     version: "{{ plugin.version | default('HEAD') }}"
   with_items: "{{ janus_vim_plugins }}"
   loop_control:


### PR DESCRIPTION
- Avoiding known public Python attributes (i.e. `.update` is a Python
  method) so that we don't need to limit ourselves to using the
  `foo['update']` syntax.
- See https://docs.ansible.com/ansible/latest/user_guide/playbooks_variables.html#what-makes-a-valid-variable-name